### PR TITLE
 Distribution.Nixpkgs.Meta: render full attr paths for maintainers plus small refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for distribution-nixpkgs
 
+## 1.7.0 (Unreleased)
+
+* `Distribution.Nixpkgs.Meta`
+  * `pPrint (x :: Meta)` now renders every maintainer as a full attribute
+    path instead of using `with`.
+
 ## 1.6.0
 
 * `Distribution.Nixpkgs.PackageMap`


### PR DESCRIPTION
<details>
<summary>Diff to `hackage-packages.nix` this generates:</summary>

(There are some unrelated changes in there due to other changes in soon to be 1.6.0)

```diff
diff --git a/pkgs/development/haskell-modules/hackage-packages.nix b/pkgs/development/haskell-modules/hackage-packages.nix
index 002629c61fd..a58db95f044 100644
--- a/pkgs/development/haskell-modules/hackage-packages.nix
+++ b/pkgs/development/haskell-modules/hackage-packages.nix
@@ -813,7 +813,7 @@ self: {
        description = "A dependently typed functional programming language and proof assistant";
        license = "unknown";
        hydraPlatforms = lib.platforms.none;
-       maintainers = with lib.maintainers; [ abbradar turion ];
+       maintainers = [ lib.maintainers.abbradar lib.maintainers.turion ];
      }) {inherit (pkgs) emacs;};
 
   "Agda-executable" = callPackage
@@ -12759,7 +12759,7 @@ self: {
        description = "an adapter for LogicGrowsOnTrees that uses MPI";
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
-     }) {openmpi = null;};
+     }) {inherit (pkgs) openmpi;};
 
   "LogicGrowsOnTrees-network" = callPackage
     ({ mkDerivation, base, cereal, cmdtheline, composition, containers
@@ -20329,7 +20329,7 @@ self: {
        ];
        description = "It provides the functionality like unix \"uniq\" utility";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ kiwi ];
+       maintainers = [ lib.maintainers.kiwi ];
      }) {};
 
   "Unixutils" = callPackage
@@ -20673,7 +20673,7 @@ self: {
        description = "Bindings to the VulkanMemoryAllocator library";
        license = lib.licenses.bsd3;
        platforms = [ "aarch64-linux" "x86_64-linux" ];
-       maintainers = with lib.maintainers; [ expipiplus1 ];
+       maintainers = [ lib.maintainers.expipiplus1 ];
      }) {};
 
   "WAVE" = callPackage
@@ -30147,7 +30147,7 @@ self: {
        description = "Medium-level language that desugars to Morte";
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "annihilator" = callPackage
@@ -32203,7 +32203,7 @@ self: {
        ];
        description = "Automatic Rule-Based Time Tracker";
        license = lib.licenses.gpl2Only;
-       maintainers = with lib.maintainers; [ maralorn rvl ];
+       maintainers = [ lib.maintainers.maralorn lib.maintainers.rvl ];
      }) {};
 
   "arcgrid" = callPackage
@@ -32292,7 +32292,7 @@ self: {
        ];
        description = "Arch Linux official and AUR web interface binding";
        license = lib.licenses.mit;
-       maintainers = with lib.maintainers; [ berberman ];
+       maintainers = [ lib.maintainers.berberman ];
      }) {};
 
   "archive" = callPackage
@@ -32696,7 +32696,7 @@ self: {
        ];
        description = "Run docker-compose with help from Nix/NixOS";
        license = lib.licenses.asl20;
-       maintainers = with lib.maintainers; [ roberth ];
+       maintainers = [ lib.maintainers.roberth ];
      }) {};
 
   "arith-encode" = callPackage
@@ -35608,7 +35608,7 @@ self: {
        testHaskellDepends = [ base doctest ];
        description = "Template Haskell to automatically pass values to functions";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ expipiplus1 ];
+       maintainers = [ lib.maintainers.expipiplus1 ];
      }) {};
 
   "autoexporter" = callPackage
@@ -39527,7 +39527,7 @@ self: {
        ];
        description = "Command-line benchmark tool";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "bench-graph" = callPackage
@@ -41322,7 +41322,7 @@ self: {
        license = "unknown";
        hydraPlatforms = lib.platforms.none;
        broken = true;
-     }) {inherit (pkgs) blas; liblapack = null;};
+     }) {inherit (pkgs) blas; inherit (pkgs) liblapack;};
 
   "bindings-libcddb" = callPackage
     ({ mkDerivation, base, bindings-DSL, libcddb }:
@@ -45459,7 +45459,7 @@ self: {
        libraryHaskellDepends = [ base mtl transformers ];
        description = "Break from a loop";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "breakout" = callPackage
@@ -48637,7 +48637,7 @@ self: {
        doHaddock = false;
        description = "Format .cabal files";
        license = "GPL-3.0-or-later AND BSD-3-Clause";
-       maintainers = with lib.maintainers; [ maralorn ];
+       maintainers = [ lib.maintainers.maralorn ];
      }) {};
 
   "cabal-ghc-dynflags" = callPackage
@@ -48770,7 +48770,7 @@ self: {
        '';
        description = "The command-line interface for Cabal and Hackage";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ peti ];
+       maintainers = [ lib.maintainers.peti ];
      }) {};
 
   "cabal-install-bundle" = callPackage
@@ -49349,7 +49349,7 @@ self: {
        '';
        description = "Convert Cabal files into Nix build instructions";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ peti ];
+       maintainers = [ lib.maintainers.peti ];
      }) {};
 
   "cabal2spec" = callPackage
@@ -49371,7 +49371,7 @@ self: {
        testHaskellDepends = [ base Cabal filepath tasty tasty-golden ];
        description = "Convert Cabal files into rpm spec files";
        license = lib.licenses.gpl3Only;
-       maintainers = with lib.maintainers; [ peti ];
+       maintainers = [ lib.maintainers.peti ];
      }) {};
 
   "cabalQuery" = callPackage
@@ -51268,7 +51268,7 @@ self: {
        libraryHaskellDepends = [ base text ];
        description = "Track string casing in its type";
        license = lib.licenses.mit;
-       maintainers = with lib.maintainers; [ jb55 ];
+       maintainers = [ lib.maintainers.jb55 ];
      }) {};
 
   "caseof" = callPackage
@@ -52039,7 +52039,7 @@ self: {
        testToolDepends = [ hspec-discover ];
        description = "Cayenne Low Power Payload";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ sorki ];
+       maintainers = [ lib.maintainers.sorki ];
      }) {};
 
   "cayley-client" = callPackage
@@ -61821,7 +61821,7 @@ self: {
        testHaskellDepends = [ base config-value text ];
        description = "Schema definitions for the config-value package";
        license = lib.licenses.isc;
-       maintainers = with lib.maintainers; [ kiwi ];
+       maintainers = [ lib.maintainers.kiwi ];
      }) {};
 
   "config-select" = callPackage
@@ -61854,7 +61854,7 @@ self: {
        testHaskellDepends = [ base text ];
        description = "Simple, layout-based value language similar to YAML or JSON";
        license = lib.licenses.mit;
-       maintainers = with lib.maintainers; [ kiwi ];
+       maintainers = [ lib.maintainers.kiwi ];
      }) {};
 
   "config-value-getopt" = callPackage
@@ -64591,7 +64591,7 @@ self: {
        license = lib.licenses.gpl3Only;
        hydraPlatforms = lib.platforms.none;
        broken = true;
-     }) {python3 = null;};
+     }) {inherit (pkgs) python3;};
 
   "cql" = callPackage
     ({ mkDerivation, base, bytestring, cereal, containers, Decimal
@@ -69999,7 +69999,7 @@ self: {
        ];
        description = "ARM SVD and CubeMX XML parser and pretty printer for STM32 family";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ sorki ];
+       maintainers = [ lib.maintainers.sorki ];
      }) {};
 
   "data-store" = callPackage
@@ -73527,7 +73527,7 @@ self: {
        description = "A configuration language guaranteed to terminate";
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "dhall" = callPackage
@@ -73584,7 +73584,7 @@ self: {
        doCheck = false;
        description = "A configuration language guaranteed to terminate";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "dhall-bash" = callPackage
@@ -73608,7 +73608,7 @@ self: {
        ];
        description = "Compile Dhall to Bash";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "dhall-check" = callPackage
@@ -73659,7 +73659,7 @@ self: {
        description = "Generate HTML docs from a dhall package";
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "dhall-fly" = callPackage
@@ -73723,7 +73723,7 @@ self: {
        ];
        description = "Convert between Dhall and JSON or YAML";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "dhall-lex" = callPackage
@@ -73774,7 +73774,7 @@ self: {
        ];
        description = "Language Server Protocol (LSP) server for Dhall";
        license = lib.licenses.mit;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "dhall-nix" = callPackage
@@ -73798,7 +73798,7 @@ self: {
        ];
        description = "Dhall to Nix compiler";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "dhall-nixpkgs" = callPackage
@@ -73822,7 +73822,7 @@ self: {
        ];
        description = "Convert Dhall projects to Nix packages";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "dhall-openapi" = callPackage
@@ -73847,7 +73847,7 @@ self: {
        ];
        description = "Convert an OpenAPI specification to a Dhall package";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "dhall-recursive-adt" = callPackage
@@ -73886,7 +73886,7 @@ self: {
        description = "Template text using Dhall";
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
        broken = true;
      }) {};
 
@@ -73946,7 +73946,7 @@ self: {
        ];
        description = "Convert between Dhall and YAML";
        license = lib.licenses.gpl3Only;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "dhcp-lease-parser" = callPackage
@@ -75976,7 +75976,7 @@ self: {
        ];
        description = "Easily stream directory contents in constant memory";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "dirtree" = callPackage
@@ -77066,7 +77066,7 @@ self: {
        testHaskellDepends = [ base deepseq hspec lens ];
        description = "Types and functions to manipulate the Nixpkgs distribution";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ peti ];
+       maintainers = [ lib.maintainers.peti ];
      }) {};
 
   "distribution-opensuse" = callPackage
@@ -80014,7 +80014,7 @@ self: {
        testHaskellDepends = [ base tasty tasty-hunit transformers ];
        description = "Generalised reactive framework supporting classic, arrowized and monadic FRP";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ turion ];
+       maintainers = [ lib.maintainers.turion ];
      }) {};
 
   "dunai-core" = callPackage
@@ -82608,7 +82608,7 @@ self: {
        ];
        description = "elm-export persistent entities";
        license = lib.licenses.mit;
-       maintainers = with lib.maintainers; [ jb55 ];
+       maintainers = [ lib.maintainers.jb55 ];
      }) {};
 
   "elm-get" = callPackage
@@ -84855,7 +84855,7 @@ self: {
        ];
        description = "Simplified error-handling";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "errors-ext" = callPackage
@@ -85190,7 +85190,7 @@ self: {
        ];
        description = "General purpose live coding framework";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ turion ];
+       maintainers = [ lib.maintainers.turion ];
      }) {};
 
   "essence-of-live-coding-gloss" = callPackage
@@ -85206,7 +85206,7 @@ self: {
        ];
        description = "General purpose live coding framework - Gloss backend";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ turion ];
+       maintainers = [ lib.maintainers.turion ];
      }) {};
 
   "essence-of-live-coding-gloss-example" = callPackage
@@ -85240,7 +85240,7 @@ self: {
        ];
        description = "General purpose live coding framework - pulse backend";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ turion ];
+       maintainers = [ lib.maintainers.turion ];
      }) {};
 
   "essence-of-live-coding-pulse-example" = callPackage
@@ -85275,7 +85275,7 @@ self: {
        ];
        description = "General purpose live coding framework - QuickCheck integration";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ turion ];
+       maintainers = [ lib.maintainers.turion ];
      }) {};
 
   "essence-of-live-coding-warp" = callPackage
@@ -86425,7 +86425,7 @@ self: {
        benchmarkHaskellDepends = [ base criterion ];
        description = "Exact real arithmetic";
        license = lib.licenses.mit;
-       maintainers = with lib.maintainers; [ expipiplus1 ];
+       maintainers = [ lib.maintainers.expipiplus1 ];
      }) {};
 
   "exact-real-positional" = callPackage
@@ -88614,7 +88614,7 @@ self: {
        testToolDepends = [ hspec-discover ];
        description = "A fast logging system";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ sternenseemann ];
+       maintainers = [ lib.maintainers.sternenseemann ];
      }) {};
 
   "fast-math" = callPackage
@@ -91233,7 +91233,7 @@ self: {
        libraryHaskellDepends = [ base deepseq ];
        description = "A type inhabited by finitely many values, indexed by type-level naturals";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ turion ];
+       maintainers = [ lib.maintainers.turion ];
      }) {};
 
   "finito" = callPackage
@@ -92177,7 +92177,7 @@ self: {
        ];
        description = "Principled and efficient bit-oriented binary serialization";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ sternenseemann ];
+       maintainers = [ lib.maintainers.sternenseemann ];
      }) {};
 
   "flat-maybe" = callPackage
@@ -93369,7 +93369,7 @@ self: {
        benchmarkHaskellDepends = [ base criterion ];
        description = "Composable, streaming, and efficient left folds";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "foldl-exceptions" = callPackage
@@ -96288,7 +96288,7 @@ self: {
        libraryHaskellDepends = [ base filepath pretty process ];
        description = "Functional MetaPost is a Haskell frontend to the MetaPost language";
        license = lib.licenses.gpl3Only;
-       maintainers = with lib.maintainers; [ peti ];
+       maintainers = [ lib.maintainers.peti ];
      }) {};
 
   "funcons-intgen" = callPackage
@@ -97935,7 +97935,7 @@ self: {
        testToolDepends = [ hspec-discover ];
        description = "GCode processor";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ sorki ];
+       maintainers = [ lib.maintainers.sorki ];
      }) {};
 
   "gconf" = callPackage
@@ -98920,7 +98920,7 @@ self: {
        ];
        description = "Generically derive traversals, lenses and prisms";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ maralorn ];
+       maintainers = [ lib.maintainers.maralorn ];
      }) {};
 
   "generic-optics-lite" = callPackage
@@ -102034,7 +102034,7 @@ self: {
        benchmarkToolDepends = [ hp2pretty implicit-hie ];
        description = "The core of an IDE";
        license = lib.licenses.asl20;
-       maintainers = with lib.maintainers; [ maralorn ];
+       maintainers = [ lib.maintainers.maralorn ];
      }) {};
 
   "ghcide_1_3_0_0" = callPackage
@@ -102102,7 +102102,7 @@ self: {
        description = "The core of an IDE";
        license = lib.licenses.asl20;
        hydraPlatforms = lib.platforms.none;
-       maintainers = with lib.maintainers; [ maralorn ];
+       maintainers = [ lib.maintainers.maralorn ];
      }) {};
 
   "ghcjs-ajax" = callPackage
@@ -102441,7 +102441,7 @@ self: {
        ];
        description = "ghc toolchain installer";
        license = lib.licenses.lgpl3Only;
-       maintainers = with lib.maintainers; [ maralorn ];
+       maintainers = [ lib.maintainers.maralorn ];
      }) {};
 
   "ghczdecode" = callPackage
@@ -103463,7 +103463,7 @@ self: {
        license = lib.licenses.lgpl21Only;
        hydraPlatforms = lib.platforms.none;
        broken = true;
-     }) {gtk-mac-integration-gtk3 = null;};
+     }) {inherit (pkgs) gtk-mac-integration-gtk3;};
 
   "gi-gtksheet" = callPackage
     ({ mkDerivation, base, bytestring, Cabal, containers, gi-atk
@@ -104371,7 +104371,7 @@ self: {
        enableSharedExecutables = false;
        description = "manage files with git, without checking their contents into git";
        license = lib.licenses.agpl3Only;
-       maintainers = with lib.maintainers; [ peti ];
+       maintainers = [ lib.maintainers.peti ];
      }) {inherit (pkgs) bup; inherit (pkgs) curl; inherit (pkgs) git; 
          inherit (pkgs) gnupg; inherit (pkgs) lsof; inherit (pkgs) openssh; 
          inherit (pkgs) perl; inherit (pkgs) rsync; inherit (pkgs) wget; 
@@ -105179,7 +105179,7 @@ self: {
        ];
        description = "Wiki using happstack, git or darcs, and pandoc";
        license = "GPL";
-       maintainers = with lib.maintainers; [ sternenseemann ];
+       maintainers = [ lib.maintainers.sternenseemann ];
      }) {};
 
   "gitlab-api" = callPackage
@@ -105876,7 +105876,7 @@ self: {
        testHaskellDepends = [ base HUnit ];
        description = "Console IRC client";
        license = lib.licenses.isc;
-       maintainers = with lib.maintainers; [ kiwi ];
+       maintainers = [ lib.maintainers.kiwi ];
      }) {};
 
   "gll" = callPackage
@@ -109438,7 +109438,7 @@ self: {
        ];
        description = "proxy gopher over http";
        license = lib.licenses.gpl3Only;
-       maintainers = with lib.maintainers; [ sternenseemann ];
+       maintainers = [ lib.maintainers.sternenseemann ];
      }) {};
 
   "gopherbot" = callPackage
@@ -112393,7 +112393,7 @@ self: {
        license = lib.licenses.lgpl21Only;
        hydraPlatforms = lib.platforms.none;
        broken = true;
-     }) {gtk-mac-integration-gtk3 = null;};
+     }) {inherit (pkgs) gtk-mac-integration-gtk3;};
 
   "gtkglext" = callPackage
     ({ mkDerivation, base, Cabal, glib, gtk, gtk2, gtk2hs-buildtools
@@ -113183,7 +113183,7 @@ self: {
        license = "GPL";
        hydraPlatforms = lib.platforms.none;
        broken = true;
-     }) {inherit (pkgs) blas; liblapack = null;};
+     }) {inherit (pkgs) blas; inherit (pkgs) liblapack;};
 
   "hXmixer" = callPackage
     ({ mkDerivation, base, directory, gtk3, process, split, text }:
@@ -113756,7 +113756,7 @@ self: {
        ];
        description = "Access cabal-install's Hackage database via Data.Map";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ peti ];
+       maintainers = [ lib.maintainers.peti ];
      }) {};
 
   "hackage-diff" = callPackage
@@ -114964,7 +114964,7 @@ self: {
        testToolDepends = [ utillinux ];
        description = "A static website compiler library";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ erictapen ];
+       maintainers = [ lib.maintainers.erictapen ];
      }) {inherit (pkgs) utillinux;};
 
   "hakyll-R" = callPackage
@@ -115090,7 +115090,7 @@ self: {
        description = "automatic hyphenation for Hakyll";
        license = lib.licenses.mit;
        hydraPlatforms = lib.platforms.none;
-       maintainers = with lib.maintainers; [ erictapen ];
+       maintainers = [ lib.maintainers.erictapen ];
      }) {};
 
   "hakyll-contrib-i18n" = callPackage
@@ -119024,7 +119024,7 @@ self: {
        testToolDepends = [ ghcide ];
        description = "LSP server for GHC";
        license = lib.licenses.asl20;
-       maintainers = with lib.maintainers; [ maralorn ];
+       maintainers = [ lib.maintainers.maralorn ];
      }) {};
 
   "haskell-lexer" = callPackage
@@ -119182,7 +119182,7 @@ self: {
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
        broken = true;
-     }) {open-pal = null; open-rte = null; openmpi = null;};
+     }) {open-pal = null; open-rte = null; inherit (pkgs) openmpi;};
 
   "haskell-names" = callPackage
     ({ mkDerivation, aeson, base, bytestring, containers
@@ -123371,7 +123371,7 @@ self: {
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
        broken = true;
-     }) {inherit (pkgs) blas; liblapack = null;};
+     }) {inherit (pkgs) blas; inherit (pkgs) liblapack;};
 
   "hblock" = callPackage
     ({ mkDerivation, aeson, base, blaze-markup, bytestring, cereal
@@ -124676,7 +124676,7 @@ self: {
        ];
        description = "Release with confidence";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ maralorn ];
+       maintainers = [ lib.maintainers.maralorn ];
      }) {};
 
   "hedgehog-checkers" = callPackage
@@ -125668,7 +125668,7 @@ self: {
        ];
        description = "Runs Continuous Integration tasks on your machines";
        license = lib.licenses.asl20;
-       maintainers = with lib.maintainers; [ roberth ];
+       maintainers = [ lib.maintainers.roberth ];
      }) {bdw-gc = null; inherit (pkgs) boost; inherit (pkgs) nix;};
 
   "hercules-ci-api" = callPackage
@@ -125699,7 +125699,7 @@ self: {
        ];
        description = "Hercules CI API definition with Servant";
        license = lib.licenses.asl20;
-       maintainers = with lib.maintainers; [ roberth ];
+       maintainers = [ lib.maintainers.roberth ];
      }) {};
 
   "hercules-ci-api-agent" = callPackage
@@ -125728,7 +125728,7 @@ self: {
        ];
        description = "API definition for Hercules CI Agent to talk to hercules-ci.com or Hercules CI Enterprise";
        license = lib.licenses.asl20;
-       maintainers = with lib.maintainers; [ roberth ];
+       maintainers = [ lib.maintainers.roberth ];
      }) {};
 
   "hercules-ci-api-core" = callPackage
@@ -125751,7 +125751,7 @@ self: {
        ];
        description = "Types and convenience modules use across Hercules CI API packages";
        license = lib.licenses.asl20;
-       maintainers = with lib.maintainers; [ roberth ];
+       maintainers = [ lib.maintainers.roberth ];
      }) {};
 
   "hercules-ci-cli" = callPackage
@@ -125791,7 +125791,7 @@ self: {
        description = "The hci command for working with Hercules CI";
        license = lib.licenses.asl20;
        hydraPlatforms = lib.platforms.none;
-       maintainers = with lib.maintainers; [ roberth ];
+       maintainers = [ lib.maintainers.roberth ];
        broken = true;
      }) {hercules-ci-optparse-applicative = null;};
 
@@ -125812,7 +125812,7 @@ self: {
        libraryPkgconfigDepends = [ bdw-gc nix ];
        description = "Bindings for the Nix evaluator";
        license = lib.licenses.asl20;
-       maintainers = with lib.maintainers; [ roberth ];
+       maintainers = [ lib.maintainers.roberth ];
      }) {bdw-gc = null; inherit (pkgs) boost; inherit (pkgs) nix;};
 
   "hercules-ci-cnix-store" = callPackage
@@ -125831,7 +125831,7 @@ self: {
        libraryPkgconfigDepends = [ nix ];
        description = "Haskell bindings for Nix's libstore";
        license = lib.licenses.asl20;
-       maintainers = with lib.maintainers; [ roberth ];
+       maintainers = [ lib.maintainers.roberth ];
      }) {inherit (pkgs) boost; inherit (pkgs) nix;};
 
   "here" = callPackage
@@ -128385,7 +128385,7 @@ self: {
        ];
        description = "Generic project initialization tool";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ poscat ];
+       maintainers = [ lib.maintainers.poscat ];
      }) {};
 
   "hinotify_0_3_9" = callPackage
@@ -129503,7 +129503,7 @@ self: {
        ];
        description = "Command-line interface for the hledger accounting system";
        license = lib.licenses.gpl3Only;
-       maintainers = with lib.maintainers; [ peti ];
+       maintainers = [ lib.maintainers.peti ];
      }) {};
 
   "hledger-api" = callPackage
@@ -129638,7 +129638,7 @@ self: {
        ];
        description = "computes interest for a given account";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ peti ];
+       maintainers = [ lib.maintainers.peti ];
      }) {};
 
   "hledger-irr" = callPackage
@@ -129766,7 +129766,7 @@ self: {
        ];
        description = "Curses-style terminal interface for the hledger accounting system";
        license = lib.licenses.gpl3Only;
-       maintainers = with lib.maintainers; [ peti ];
+       maintainers = [ lib.maintainers.peti ];
      }) {};
 
   "hledger-vty" = callPackage
@@ -129821,7 +129821,7 @@ self: {
        ];
        description = "Web-based user interface for the hledger accounting system";
        license = lib.licenses.gpl3Only;
-       maintainers = with lib.maintainers; [ peti ];
+       maintainers = [ lib.maintainers.peti ];
      }) {};
 
   "hlibBladeRF" = callPackage
@@ -129936,7 +129936,7 @@ self: {
        description = "Source code suggestions";
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
-       maintainers = with lib.maintainers; [ maralorn ];
+       maintainers = [ lib.maintainers.maralorn ];
      }) {};
 
   "hlint" = callPackage
@@ -129962,7 +129962,7 @@ self: {
        executableHaskellDepends = [ base ];
        description = "Source code suggestions";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ maralorn ];
+       maintainers = [ lib.maintainers.maralorn ];
      }) {};
 
   "hlint-test" = callPackage
@@ -130568,7 +130568,7 @@ self: {
        librarySystemDepends = [ openblasCompat ];
        description = "Numeric Linear Algebra";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ maralorn ];
+       maintainers = [ lib.maintainers.maralorn ];
      }) {inherit (pkgs) openblasCompat;};
 
   "hmatrix-backprop" = callPackage
@@ -130607,7 +130607,7 @@ self: {
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
        broken = true;
-     }) {liblapack = null;};
+     }) {inherit (pkgs) liblapack;};
 
   "hmatrix-csv" = callPackage
     ({ mkDerivation, base, bytestring, cassava, hmatrix, vector }:
@@ -130694,7 +130694,7 @@ self: {
        benchmarkHaskellDepends = [ base criterion hmatrix ];
        description = "Low-level machine learning auxiliary functions";
        license = lib.licenses.bsd3;
-     }) {inherit (pkgs) blas; liblapack = null;};
+     }) {inherit (pkgs) blas; inherit (pkgs) liblapack;};
 
   "hmatrix-nipals" = callPackage
     ({ mkDerivation, base, hmatrix }:
@@ -132548,7 +132548,7 @@ self: {
        testHaskellDepends = [ base bytestring HUnit ];
        description = "FFI Bindings to OpenSSL's EVP Digest Interface";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ peti ];
+       maintainers = [ lib.maintainers.peti ];
      }) {inherit (pkgs) openssl;};
 
   "hopfield" = callPackage
@@ -136249,7 +136249,7 @@ self: {
        librarySystemDepends = [ adns ];
        description = "Asynchronous DNS Resolver";
        license = lib.licenses.lgpl3Only;
-       maintainers = with lib.maintainers; [ peti ];
+       maintainers = [ lib.maintainers.peti ];
      }) {inherit (pkgs) adns;};
 
   "hsdns-cache" = callPackage
@@ -136307,7 +136307,7 @@ self: {
        testHaskellDepends = [ base hspec parsec time ];
        description = "Parsec parsers for the Internet Message format (e-mail)";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ peti ];
+       maintainers = [ lib.maintainers.peti ];
      }) {};
 
   "hsemail-ns" = callPackage
@@ -136562,7 +136562,8 @@ self: {
        libraryPkgconfigDepends = [ gsl ];
        description = "Signal processing and EEG data analysis";
        license = lib.licenses.bsd3;
-     }) {inherit (pkgs) blas; inherit (pkgs) gsl; liblapack = null;};
+     }) {inherit (pkgs) blas; inherit (pkgs) gsl; 
+         inherit (pkgs) liblapack;};
 
   "hsilop" = callPackage
     ({ mkDerivation, base, directory, filepath, haskeline, xdg-basedir
@@ -139137,7 +139138,7 @@ self: {
        libraryHaskellDepends = [ base ];
        description = "FFI interface to syslog(3) from POSIX.1-2001";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ peti ];
+       maintainers = [ lib.maintainers.peti ];
      }) {};
 
   "hsyslog-tcp" = callPackage
@@ -144472,7 +144473,7 @@ self: {
        ];
        description = "iCalendar data types, parser, and printer";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ maralorn ];
+       maintainers = [ lib.maintainers.maralorn ];
      }) {};
 
   "iException" = callPackage
@@ -146726,7 +146727,7 @@ self: {
        description = "Indexed Types";
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
        broken = true;
      }) {};
 
@@ -149576,7 +149577,7 @@ self: {
        testHaskellDepends = [ base hashable HUnit text ];
        description = "IRC core library for glirc";
        license = lib.licenses.isc;
-       maintainers = with lib.maintainers; [ kiwi ];
+       maintainers = [ lib.maintainers.kiwi ];
      }) {};
 
   "irc-ctcp" = callPackage
@@ -151048,7 +151049,7 @@ self: {
        executableHaskellDepends = [ base Cabal ];
        description = "Strip version restrictions from Cabal files";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ peti ];
+       maintainers = [ lib.maintainers.peti ];
      }) {};
 
   "jalaali" = callPackage
@@ -152693,7 +152694,7 @@ self: {
        license = lib.licenses.mit;
        hydraPlatforms = lib.platforms.none;
        broken = true;
-     }) {python = null;};
+     }) {inherit (pkgs) python;};
 
   "json-qq" = callPackage
     ({ mkDerivation, base, haskell-src-meta, parsec, template-haskell
@@ -157705,7 +157706,7 @@ self: {
        testHaskellDepends = [ base directory filepath process ];
        description = "Analysis and generation of C code";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ expipiplus1 ];
+       maintainers = [ lib.maintainers.expipiplus1 ];
      }) {};
 
   "language-c_0_9_0_1" = callPackage
@@ -157725,7 +157726,7 @@ self: {
        description = "Analysis and generation of C code";
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
-       maintainers = with lib.maintainers; [ expipiplus1 ];
+       maintainers = [ lib.maintainers.expipiplus1 ];
      }) {};
 
   "language-c-comments" = callPackage
@@ -158438,7 +158439,7 @@ self: {
        ];
        description = "Data types and functions to represent the Nix language";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ peti ];
+       maintainers = [ lib.maintainers.peti ];
      }) {};
 
   "language-oberon" = callPackage
@@ -158986,7 +158987,7 @@ self: {
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
        broken = true;
-     }) {liblapack = null;};
+     }) {inherit (pkgs) liblapack;};
 
   "lapack-ffi-tools" = callPackage
     ({ mkDerivation, base, bytestring, cassava, containers
@@ -159041,7 +159042,7 @@ self: {
        platforms = [
          "armv7l-linux" "i686-linux" "x86_64-darwin" "x86_64-linux"
        ];
-       maintainers = with lib.maintainers; [ sternenseemann ];
+       maintainers = [ lib.maintainers.sternenseemann ];
      }) {};
 
   "largeword" = callPackage
@@ -160845,7 +160846,7 @@ self: {
        description = "Tutorial for the lens library";
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
        broken = true;
      }) {};
 
@@ -160942,7 +160943,7 @@ self: {
        ];
        description = "frugal issue tracker";
        license = lib.licenses.gpl3Only;
-       maintainers = with lib.maintainers; [ rvl ];
+       maintainers = [ lib.maintainers.rvl ];
      }) {};
 
   "lenz" = callPackage
@@ -164467,7 +164468,7 @@ self: {
        testHaskellDepends = [ base doctest ];
        description = "List monad transformer";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "list-tries" = callPackage
@@ -165604,7 +165605,7 @@ self: {
        benchmarkHaskellDepends = [ base criterion ];
        description = "Location-aware variants of partial functions";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ gridaphobe ];
+       maintainers = [ lib.maintainers.gridaphobe ];
      }) {};
 
   "located-monad-logger" = callPackage
@@ -166198,7 +166199,7 @@ self: {
        libraryHaskellDepends = [ base hsyslog logging-facade ];
        description = "A logging back-end to syslog(3) for the logging-facade library";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ peti ];
+       maintainers = [ lib.maintainers.peti ];
      }) {};
 
   "logic-TPTP" = callPackage
@@ -169153,7 +169154,7 @@ self: {
        libraryHaskellDepends = [ base transformers ];
        description = "A monad for managed values";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "manatee" = callPackage
@@ -171072,7 +171073,7 @@ self: {
        ];
        description = "Terminal client for the Mattermost chat system";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ kiwi ];
+       maintainers = [ lib.maintainers.kiwi ];
      }) {};
 
   "mattermost-api" = callPackage
@@ -171101,7 +171102,7 @@ self: {
        ];
        description = "Client API for Mattermost chat system";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ kiwi ];
+       maintainers = [ lib.maintainers.kiwi ];
      }) {};
 
   "mattermost-api-qc" = callPackage
@@ -171117,7 +171118,7 @@ self: {
        ];
        description = "QuickCheck instances for the Mattermost client API library";
        license = lib.licenses.isc;
-       maintainers = with lib.maintainers; [ kiwi ];
+       maintainers = [ lib.maintainers.kiwi ];
      }) {};
 
   "maude" = callPackage
@@ -175361,7 +175362,7 @@ self: {
        description = "Monad morphisms";
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "mmorph" = callPackage
@@ -175377,7 +175378,7 @@ self: {
        ];
        description = "Monad morphisms";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "mmsyn2" = callPackage
@@ -178818,7 +178819,7 @@ self: {
        description = "A bare-bones calculus of constructions";
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
        broken = true;
      }) {};
 
@@ -181721,7 +181722,7 @@ self: {
        description = "Model-view-controller";
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
        broken = true;
      }) {};
 
@@ -181735,7 +181736,7 @@ self: {
        description = "Concurrent and combinable updates";
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "mvclient" = callPackage
@@ -185752,7 +185753,7 @@ self: {
        doHaddock = false;
        description = "Future-proof system for plain-text notes";
        license = lib.licenses.agpl3Only;
-       maintainers = with lib.maintainers; [ maralorn ];
+       maintainers = [ lib.maintainers.maralorn ];
      }) {};
 
   "newbase60" = callPackage
@@ -186449,7 +186450,7 @@ self: {
        benchmarkHaskellDepends = [ attoparsec base criterion text ];
        description = "Parse and render *.drv files";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 sorki ];
+       maintainers = [ lib.maintainers.Gabriel439 lib.maintainers.sorki ];
      }) {};
 
   "nix-diff" = callPackage
@@ -186469,7 +186470,9 @@ self: {
        ];
        description = "Explain why two Nix derivations differ";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 terlar ];
+       maintainers = [
+         lib.maintainers.Gabriel439 lib.maintainers.terlar
+       ];
      }) {};
 
   "nix-eval" = callPackage
@@ -186559,7 +186562,7 @@ self: {
        ];
        description = "Parse and render .narinfo files";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ sorki ];
+       maintainers = [ lib.maintainers.sorki ];
      }) {};
 
   "nix-paths" = callPackage
@@ -186572,7 +186575,7 @@ self: {
        libraryToolDepends = [ nix ];
        description = "Knowledge of Nix's installation directories";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ peti ];
+       maintainers = [ lib.maintainers.peti ];
      }) {inherit (pkgs) nix;};
 
   "nix-thunk" = callPackage
@@ -186657,7 +186660,7 @@ self: {
        ];
        description = "Interactively browse a Nix store paths dependencies";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ utdemir ];
+       maintainers = [ lib.maintainers.utdemir ];
      }) {};
 
   "nixdu" = callPackage
@@ -188781,7 +188784,7 @@ self: {
        ];
        description = "Generate nix sources expr for the latest version of packages";
        license = lib.licenses.mit;
-       maintainers = with lib.maintainers; [ berberman ];
+       maintainers = [ lib.maintainers.berberman ];
      }) {};
 
   "nvim-hs" = callPackage
@@ -191846,7 +191849,7 @@ self: {
        ];
        description = "Optics as an abstract interface";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ maralorn ];
+       maintainers = [ lib.maintainers.maralorn ];
      }) {};
 
   "optics_0_4" = callPackage
@@ -191876,7 +191879,7 @@ self: {
        description = "Optics as an abstract interface";
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
-       maintainers = with lib.maintainers; [ maralorn ];
+       maintainers = [ lib.maintainers.maralorn ];
      }) {};
 
   "optics-core" = callPackage
@@ -192137,7 +192140,7 @@ self: {
        libraryHaskellDepends = [ base ];
        description = "Optional function arguments";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "options" = callPackage
@@ -192264,7 +192267,7 @@ self: {
        ];
        description = "Auto-generate a command-line parser for your datatype";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "optparse-helper" = callPackage
@@ -192341,7 +192344,7 @@ self: {
        ];
        description = "Types and functions for Kepler orbits";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ expipiplus1 ];
+       maintainers = [ lib.maintainers.expipiplus1 ];
      }) {};
 
   "orc" = callPackage
@@ -193829,7 +193832,7 @@ self: {
        platforms = [
          "aarch64-linux" "armv7l-linux" "i686-linux" "x86_64-linux"
        ];
-     }) {pam = null;};
+     }) {inherit (pkgs) pam;};
 
   "pan-os-syslog" = callPackage
     ({ mkDerivation, base, byteslice, bytesmith, chronos, gauge, ip
@@ -193925,7 +193928,7 @@ self: {
        '';
        description = "Conversion between markup formats";
        license = lib.licenses.gpl2Plus;
-       maintainers = with lib.maintainers; [ peti ];
+       maintainers = [ lib.maintainers.peti ];
      }) {};
 
   "pandoc_2_14_0_1" = callPackage
@@ -193984,7 +193987,7 @@ self: {
        description = "Conversion between markup formats";
        license = lib.licenses.gpl2Plus;
        hydraPlatforms = lib.platforms.none;
-       maintainers = with lib.maintainers; [ peti ];
+       maintainers = [ lib.maintainers.peti ];
      }) {};
 
   "pandoc-citeproc" = callPackage
@@ -196552,7 +196555,7 @@ self: {
        description = "Hashing and checking of passwords";
        license = lib.licenses.bsd3;
        platforms = [ "i686-linux" "x86_64-darwin" "x86_64-linux" ];
-       maintainers = with lib.maintainers; [ cdepillabout ];
+       maintainers = [ lib.maintainers.cdepillabout ];
      }) {};
 
   "password-instances" = callPackage
@@ -196577,7 +196580,7 @@ self: {
        description = "typeclass instances for password package";
        license = lib.licenses.bsd3;
        platforms = [ "i686-linux" "x86_64-darwin" "x86_64-linux" ];
-       maintainers = with lib.maintainers; [ cdepillabout ];
+       maintainers = [ lib.maintainers.cdepillabout ];
      }) {};
 
   "password-types" = callPackage
@@ -196909,7 +196912,7 @@ self: {
        testHaskellDepends = [ base hspec HUnit QuickCheck text ];
        description = "Components of paths";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ psibi ];
+       maintainers = [ lib.maintainers.psibi ];
      }) {};
 
   "path-text-utf8" = callPackage
@@ -198806,7 +198809,7 @@ self: {
        ];
        description = "Type-safe, multi-backend data serialization";
        license = lib.licenses.mit;
-       maintainers = with lib.maintainers; [ psibi ];
+       maintainers = [ lib.maintainers.psibi ];
      }) {};
 
   "persistent-audit" = callPackage
@@ -199434,7 +199437,7 @@ self: {
        ];
        description = "Backend for the persistent library using sqlite3";
        license = lib.licenses.mit;
-       maintainers = with lib.maintainers; [ psibi ];
+       maintainers = [ lib.maintainers.psibi ];
      }) {inherit (pkgs) sqlite;};
 
   "persistent-template" = callPackage
@@ -199447,7 +199450,7 @@ self: {
        doHaddock = false;
        description = "Type-safe, non-relational, multi-backend persistence";
        license = lib.licenses.mit;
-       maintainers = with lib.maintainers; [ psibi ];
+       maintainers = [ lib.maintainers.psibi ];
      }) {};
 
   "persistent-template-classy" = callPackage
@@ -201115,7 +201118,7 @@ self: {
        ];
        description = "Back up the notes you've saved to Pinboard";
        license = lib.licenses.gpl3Only;
-       maintainers = with lib.maintainers; [ bdesham ];
+       maintainers = [ lib.maintainers.bdesham ];
      }) {};
 
   "pinch" = callPackage
@@ -201401,7 +201404,7 @@ self: {
        ];
        description = "Compositional pipelines";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "pipes-aeson" = callPackage
@@ -201567,7 +201570,7 @@ self: {
        ];
        description = "ByteString support for pipes";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "pipes-bzip" = callPackage
@@ -201736,7 +201739,7 @@ self: {
        testHaskellDepends = [ async base pipes stm ];
        description = "Concurrency for the pipes ecosystem";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "pipes-conduit" = callPackage
@@ -201799,7 +201802,7 @@ self: {
        ];
        description = "Fast, streaming csv parser";
        license = lib.licenses.mit;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "pipes-errors" = callPackage
@@ -201859,7 +201862,7 @@ self: {
        ];
        description = "Extra utilities for pipes";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "pipes-fastx" = callPackage
@@ -201943,7 +201946,7 @@ self: {
        testHaskellDepends = [ base doctest lens-family-core ];
        description = "Group streams into substreams";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "pipes-http" = callPackage
@@ -201961,7 +201964,7 @@ self: {
        ];
        description = "HTTP client with pipes interface";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "pipes-illumina" = callPackage
@@ -202223,7 +202226,7 @@ self: {
        libraryHaskellDepends = [ base pipes transformers ];
        description = "Parsing infrastructure for the pipes ecosystem";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "pipes-postgresql-simple" = callPackage
@@ -202346,7 +202349,7 @@ self: {
        ];
        description = "Safety for the pipes ecosystem";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "pipes-shell" = callPackage
@@ -207990,7 +207993,7 @@ self: {
        benchmarkHaskellDepends = [ base criterion text ];
        description = "pretty printer for data types with a 'Show' instance";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ cdepillabout ];
+       maintainers = [ lib.maintainers.cdepillabout ];
      }) {};
 
   "pretty-sop" = callPackage
@@ -211525,7 +211528,7 @@ self: {
        librarySystemDepends = [ libpulseaudio ];
        description = "binding to Simple API of pulseaudio";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ turion ];
+       maintainers = [ lib.maintainers.turion ];
      }) {inherit (pkgs) libpulseaudio;};
 
   "pulseaudio" = callPackage
@@ -212468,7 +212471,7 @@ self: {
        license = lib.licenses.mit;
        hydraPlatforms = lib.platforms.none;
        broken = true;
-     }) {python = null;};
+     }) {inherit (pkgs) python;};
 
   "pyfi" = callPackage
     ({ mkDerivation, aeson, base, bytestring, containers, pureMD5
@@ -212486,7 +212489,7 @@ self: {
        license = lib.licenses.mit;
        hydraPlatforms = lib.platforms.none;
        broken = true;
-     }) {python = null;};
+     }) {inherit (pkgs) python;};
 
   "python-pickle" = callPackage
     ({ mkDerivation, attoparsec, base, bytestring, cereal, cmdargs
@@ -217897,7 +217900,7 @@ self: {
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
        broken = true;
-     }) {raptor2 = null; redland = null;};
+     }) {raptor2 = null; inherit (pkgs) redland;};
 
   "redo" = callPackage
     ({ mkDerivation, base, bytestring, containers, directory, filepath
@@ -218414,7 +218417,7 @@ self: {
        description = "Functional Reactive Web Apps with Reflex";
        license = lib.licenses.bsd3;
        platforms = [ "armv7l-linux" "i686-linux" "x86_64-linux" ];
-       maintainers = with lib.maintainers; [ maralorn ];
+       maintainers = [ lib.maintainers.maralorn ];
      }) {};
 
   "reflex-dom-ace" = callPackage
@@ -220432,7 +220435,7 @@ self: {
        executableHaskellDepends = [ base ];
        description = "Automation of Haskell package release process";
        license = lib.licenses.asl20;
-       maintainers = with lib.maintainers; [ maralorn ];
+       maintainers = [ lib.maintainers.maralorn ];
      }) {};
 
   "relevant-time" = callPackage
@@ -221436,7 +221439,7 @@ self: {
        doCheck = false;
        description = "Easy-to-use, type-safe, expandable, high-level HTTP client library";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ maralorn ];
+       maintainers = [ lib.maintainers.maralorn ];
      }) {};
 
   "req-conduit" = callPackage
@@ -222890,7 +222893,7 @@ self: {
        ];
        description = "Functional Reactive Programming with type-level clocks";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ turion ];
+       maintainers = [ lib.maintainers.turion ];
      }) {};
 
   "rhine-gloss" = callPackage
@@ -222905,7 +222908,7 @@ self: {
        executableHaskellDepends = [ base ];
        description = "Gloss backend for Rhine";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ turion ];
+       maintainers = [ lib.maintainers.turion ];
      }) {};
 
   "rhythm-game-tutorial" = callPackage
@@ -234024,7 +234027,7 @@ self: {
        description = "Auto-generate a server for your datatype";
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
        broken = true;
      }) {};
 
@@ -235085,7 +235088,7 @@ self: {
        ];
        description = "Build rules for historical benchmarking";
        license = lib.licenses.asl20;
-       maintainers = with lib.maintainers; [ maralorn ];
+       maintainers = [ lib.maintainers.maralorn ];
      }) {};
 
   "shake-bindist" = callPackage
@@ -235488,7 +235491,7 @@ self: {
        ];
        description = "A toolkit for making compile-time interpolated templates";
        license = lib.licenses.mit;
-       maintainers = with lib.maintainers; [ psibi ];
+       maintainers = [ lib.maintainers.psibi ];
      }) {};
 
   "shakespeare-babel" = callPackage
@@ -236106,7 +236109,7 @@ self: {
        testToolDepends = [ markdown-unlit ];
        description = "Simple shell scripting from Haskell";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ maralorn ];
+       maintainers = [ lib.maintainers.maralorn ];
      }) {};
 
   "shh-extras" = callPackage
@@ -236994,7 +236997,7 @@ self: {
        ];
        description = "A simple library for affine and vector spaces";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ turion ];
+       maintainers = [ lib.maintainers.turion ];
      }) {};
 
   "simple-atom" = callPackage
@@ -240392,7 +240395,7 @@ self: {
        ];
        description = "Top-level package for the Snap Web Framework";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ maralorn ];
+       maintainers = [ lib.maintainers.maralorn ];
      }) {};
 
   "snap-accept" = callPackage
@@ -242061,7 +242064,7 @@ self: {
        ];
        description = "An extensible socket library";
        license = lib.licenses.mit;
-       maintainers = with lib.maintainers; [ sternenseemann ];
+       maintainers = [ lib.maintainers.sternenseemann ];
      }) {};
 
   "socket-activation" = callPackage
@@ -242889,7 +242892,7 @@ self: {
        ];
        description = "Gopher server library and daemon";
        license = lib.licenses.gpl3Only;
-       maintainers = with lib.maintainers; [ sternenseemann ];
+       maintainers = [ lib.maintainers.sternenseemann ];
      }) {};
 
   "spacefill" = callPackage
@@ -247177,7 +247180,7 @@ self: {
        ];
        description = "Containers for STM";
        license = lib.licenses.mit;
-       maintainers = with lib.maintainers; [ maralorn ];
+       maintainers = [ lib.maintainers.maralorn ];
      }) {};
 
   "stm-delay" = callPackage
@@ -248523,7 +248526,7 @@ self: {
        ];
        description = "Streaming Wai utilities";
        license = lib.licenses.mit;
-       maintainers = with lib.maintainers; [ jb55 ];
+       maintainers = [ lib.maintainers.jb55 ];
      }) {};
 
   "streaming-with" = callPackage
@@ -248570,7 +248573,7 @@ self: {
        ];
        description = "Beautiful Streaming, Concurrent and Reactive Composition";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ maralorn ];
+       maintainers = [ lib.maintainers.maralorn ];
      }) {};
 
   "streamly-archive" = callPackage
@@ -249902,7 +249905,7 @@ self: {
        ];
        description = "Structured editing Emacs mode for Haskell";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ peti ];
+       maintainers = [ lib.maintainers.peti ];
      }) {};
 
   "structured-mongoDB" = callPackage
@@ -253273,7 +253276,7 @@ self: {
        testHaskellDepends = [ base network unix ];
        description = "Systemd facilities (Socket activation, Notify)";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ sternenseemann ];
+       maintainers = [ lib.maintainers.sternenseemann ];
      }) {};
 
   "systemstats" = callPackage
@@ -253636,7 +253639,7 @@ self: {
        platforms = [
          "aarch64-linux" "armv7l-linux" "i686-linux" "x86_64-linux"
        ];
-       maintainers = with lib.maintainers; [ rvl ];
+       maintainers = [ lib.maintainers.rvl ];
      }) {inherit (pkgs) gtk3;};
 
   "tag-bits" = callPackage
@@ -254669,7 +254672,7 @@ self: {
        testToolDepends = [ hspec-discover ];
        description = "Types and aeson instances for taskwarrior tasks";
        license = lib.licenses.agpl3Plus;
-       maintainers = with lib.maintainers; [ maralorn ];
+       maintainers = [ lib.maintainers.maralorn ];
      }) {};
 
   "tasty" = callPackage
@@ -257185,7 +257188,7 @@ self: {
        platforms = [
          "aarch64-linux" "armv7l-linux" "i686-linux" "x86_64-linux"
        ];
-       maintainers = with lib.maintainers; [ cdepillabout ];
+       maintainers = [ lib.maintainers.cdepillabout ];
      }) {inherit (pkgs) gtk3; inherit (pkgs) pcre2; 
          vte_291 = pkgs.vte;};
 
@@ -262137,7 +262140,7 @@ self: {
        testHaskellDepends = [ base tasty tasty-hunit tasty-quickcheck ];
        description = "Convert English Words to Title Case";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ peti ];
+       maintainers = [ lib.maintainers.peti ];
      }) {};
 
   "tkhs" = callPackage
@@ -263414,7 +263417,7 @@ self: {
        libraryHaskellDepends = [ base void ];
        description = "Exhaustive pattern matching using lenses, traversals, and prisms";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "total-alternative" = callPackage
@@ -265889,7 +265892,7 @@ self: {
        ];
        description = "Things Tracker Network JSON Types";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ sorki ];
+       maintainers = [ lib.maintainers.sorki ];
      }) {};
 
   "ttn-client" = callPackage
@@ -265910,7 +265913,7 @@ self: {
        executableHaskellDepends = [ base text time ttn ];
        description = "TheThingsNetwork client";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ sorki ];
+       maintainers = [ lib.maintainers.sorki ];
      }) {};
 
   "ttrie" = callPackage
@@ -266293,7 +266296,7 @@ self: {
        benchmarkHaskellDepends = [ base criterion text ];
        description = "Shell programming, Haskell-style";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "turtle-options" = callPackage
@@ -267921,7 +267924,7 @@ self: {
        description = "Typed and composable spreadsheets";
        license = lib.licenses.bsd3;
        hydraPlatforms = lib.platforms.none;
-       maintainers = with lib.maintainers; [ Gabriel439 ];
+       maintainers = [ lib.maintainers.Gabriel439 ];
      }) {};
 
   "typed-streams" = callPackage
@@ -271473,7 +271476,9 @@ self: {
        testToolDepends = [ tasty-discover ];
        description = "A program to update fetchgit values in Nix expressions";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ expipiplus1 sorki ];
+       maintainers = [
+         lib.maintainers.expipiplus1 lib.maintainers.sorki
+       ];
      }) {};
 
   "update-repos" = callPackage
@@ -272295,7 +272300,7 @@ self: {
        ];
        description = "A pragmatic time and date library";
        license = lib.licenses.mit;
-       maintainers = with lib.maintainers; [ sternenseemann ];
+       maintainers = [ lib.maintainers.sternenseemann ];
      }) {};
 
   "utf" = callPackage
@@ -272886,7 +272891,7 @@ self: {
        ];
        description = "Tweak .cabal files";
        license = lib.licenses.mit;
-       maintainers = with lib.maintainers; [ berberman ];
+       maintainers = [ lib.maintainers.berberman ];
      }) {};
 
   "uvector" = callPackage
@@ -274398,7 +274403,7 @@ self: {
        ];
        description = "Size tagged vectors";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ expipiplus1 ];
+       maintainers = [ lib.maintainers.expipiplus1 ];
      }) {};
 
   "vector-space" = callPackage
@@ -275983,7 +275988,7 @@ self: {
        description = "Bindings to the Vulkan graphics API";
        license = lib.licenses.bsd3;
        platforms = [ "aarch64-linux" "x86_64-linux" ];
-       maintainers = with lib.maintainers; [ expipiplus1 ];
+       maintainers = [ lib.maintainers.expipiplus1 ];
      }) {vulkan = null;};
 
   "vulkan-api" = callPackage
@@ -276019,7 +276024,7 @@ self: {
        platforms = [
          "aarch64-linux" "armv7l-linux" "i686-linux" "x86_64-linux"
        ];
-       maintainers = with lib.maintainers; [ expipiplus1 ];
+       maintainers = [ lib.maintainers.expipiplus1 ];
      }) {};
 
   "waargonaut" = callPackage
@@ -279468,7 +279473,7 @@ self: {
        ];
        description = "webfont generator";
        license = lib.licenses.mit;
-       maintainers = with lib.maintainers; [ erictapen ];
+       maintainers = [ lib.maintainers.erictapen ];
      }) {};
 
   "webkit" = callPackage
@@ -284233,7 +284238,7 @@ self: {
        '';
        description = "A tiling window manager";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ peti ];
+       maintainers = [ lib.maintainers.peti ];
      }) {};
 
   "xmonad-bluetilebranch" = callPackage
@@ -284276,7 +284281,7 @@ self: {
        ];
        description = "Third party extensions for xmonad";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ peti ];
+       maintainers = [ lib.maintainers.peti ];
      }) {};
 
   "xmonad-contrib-bluetilebranch" = callPackage
@@ -285832,7 +285837,7 @@ self: {
        ];
        description = "Represent and parse yarn.lock files";
        license = lib.licenses.mit;
-       maintainers = with lib.maintainers; [ sternenseemann ];
+       maintainers = [ lib.maintainers.sternenseemann ];
      }) {};
 
   "yarn2nix" = callPackage
@@ -285870,7 +285875,7 @@ self: {
        ];
        description = "Convert yarn.lock files to nix expressions";
        license = lib.licenses.mit;
-       maintainers = with lib.maintainers; [ sternenseemann ];
+       maintainers = [ lib.maintainers.sternenseemann ];
      }) {};
 
   "yarr" = callPackage
@@ -290626,7 +290631,7 @@ self: {
        ];
        description = "ZRE protocol implementation";
        license = lib.licenses.bsd3;
-       maintainers = with lib.maintainers; [ sorki ];
+       maintainers = [ lib.maintainers.sorki ];
      }) {};
 
   "zsdd" = callPackage

```

</details>