### PR TITLE
 feat(Meta): no longer export cabalPlatformFromSystem 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,9 @@
       derivation. Not rendered if `Nothing`.
   * **API breaking change**: Remove `allKnownPlatforms`, its previous use can be
     replaced using `badPlatforms`.
-  * Added facilities for parsing platform strings:
-    * `cabalPlatformFromSystem` parses a nixpkgs system tuple into Cabal's
-      `Platform` type. Expects the string to be valid and does little validation.
-    * `nixpkgsPlatformFromString` parses a specific format used by hackage2nix's
-      config files into either `NixpkgsPlatformSingle` or `NixpkgsPlatformGroup`.
+  * Added `nixpkgsPlatformFromString` which parses a specific format used by
+    hackage2nix's config files into either `NixpkgsPlatformSingle` or
+    `NixpkgsPlatformGroup`.
 * `Language.Nix.PrettyPrinting`: Added new helpers, `listattrDoc` and
   `toAscListSortedOn`.
 

--- a/src/Distribution/Nixpkgs/Meta.hs
+++ b/src/Distribution/Nixpkgs/Meta.hs
@@ -149,6 +149,13 @@ nixpkgsPlatformFromString s = platformGroup <|> singlePlatform
 --   (from @lib.platforms@ and @lib.systems.examples@) as of 2022-05-08.
 --   Please open an issue if any newly added ones are not recognized properly.
 --
+--   __Warning__: 'cabalPlatformFromSystem' tries to preserve all information in
+--   the system tuple passed in. This means that it distinguishes between things
+--   that Cabal wouldn't, e.g. `powerpc64` and `powerpc64le`. If you use this
+--   function to obtain a 'Platform's that is later used to evaluate a @.cabal@
+--   file, it will behave unexpectedly in such situation. It is generally better
+--   to use Cabal's own facilities for this purpose.
+--
 --   >>> cabalPlatformFromSystem "x86_64-linux"
 --   Just (Platform X86_64 Linux)
 --   >>> cabalPlatformFromSystem "x86_64-linux-musl"


### PR DESCRIPTION
This function is not a general purpose conversion from a Nix system to a
Cabal Platform. We use Platform (for better or worse) to represent a Nix
system, not a Cabal platform. Thus nixpkgsPlatformFromString and the
wrapper type describe our intentions better. cabalPlatformFromSystem
should never be used to obtain a Platform and pass it to Cabal for some
purpose, so let's make that harder.

cabal2nix's Platform parsing can be independent from this and
implemented correctly: https://github.com/NixOS/cabal2nix/pull/555